### PR TITLE
fix function executable-file-p, fix executable filename of CMUCL, disable startup message of sbcl

### DIFF
--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -276,7 +276,8 @@
 (defmethod eval-in-lisp ((lisp clisp) (file pathname) with-rc)
   (run-lisp lisp "-q" "-q" "-ansi" (unless with-rc "-norc") "-x" (eval-wrapper lisp file)))
 
-(defclass cmucl (implementation) ())
+(defclass cmucl (implementation)
+  ((executable :initform '("lisp"))))
 
 (defmethod quit-form ((lisp cmucl) code)
   (format NIL "(unix:unix-exit ~d)" code))

--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -306,7 +306,7 @@
   (format NIL "(sb-ext:exit :code ~d)" code))
 
 (defmethod eval-in-lisp ((lisp sbcl) (file pathname) with-rc)
-  (run-lisp lisp "--disable-ldb" "--lose-on-corruption"
+  (run-lisp lisp "--disable-ldb" "--lose-on-corruption" "--noinform"
             (unless with-rc "--no-sysinit")
             (unless with-rc "--no-userinit")
             "--eval" (eval-wrapper lisp file)))

--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -112,7 +112,8 @@
            ;; ELF Executable
            (bytes= bytes #x7F #x45 #x4C #x46)
            ;; Mach-O Executable
-           (bytes= bytes #xFE #xED #xFA #xCE)
+           (or (bytes= bytes #xCE #xFA #xED #xFE)  ;; Mach-O Executable i386
+               (bytes= bytes #xCF #xFA #xED #xFE)) ;; Mach-O Executable x86_64
            ;; Script with a shebang
            #+unix (bytes= bytes #x23 #x21)))))))
 


### PR DESCRIPTION
- fix function `executable-file-p` about Mach-O Executable(see details below)
- disable startup message of sbcl
- fix executable filename of CMUCL(see [Extract the tarballs - Installing CMUCL](https://gitlab.common-lisp.net/cmucl/cmucl/-/wikis/InstallingCmucl#extract-the-tarballs))

Mach-O Executable related info:

```shell
file /Applications/AllegroCLexpress.app/Contents/Resources/alisp
```
=>
```=>
/Applications/AllegroCLexpress.app/Contents/Resources/alisp: Mach-O executable i386
```


```shell
xxd -l 16 /Applications/AllegroCLexpress.app/Contents/Resources/alisp
```
=>
```=>
00000000: cefa edfe 0700 0000 0300 0000 0200 0000  ................
```

```shell
file /usr/local/cmucl-21d-x86-darwin/bin/lisp
```
=>
```=>
/usr/local/cmucl-21d-x86-darwin/bin/lisp: Mach-O executable i386
```

```shell
xxd -l 16 /usr/local/cmucl-21d-x86-darwin/bin/lisp
```
=>
```=>
00000000: cefa edfe 0700 0000 0300 0000 0200 0000  ................
```

```shell
file /usr/local/Cellar/ecl/20.4.24/bin/ecl
```
=>
```=>
/usr/local/Cellar/ecl/20.4.24/bin/ecl: Mach-O 64-bit executable x86_64
```

```shell
xxd -l 16 /usr/local/Cellar/ecl/20.4.24/bin/ecl
```
=>
```=>
00000000: cffa edfe 0700 0001 0300 0080 0200 0000  ................
```