### PR TITLE
fix JSCL executable, fix Allegro: load rc files before run -e

### DIFF
--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -251,7 +251,8 @@
 (defmethod eval-in-lisp ((lisp allegro) (file pathname) with-rc)
   (run-lisp lisp
             (unless with-rc "--qq")
-            "-e" "(mapcar #'(lambda (filename) (let ((init-file (merge-pathnames filename (user-homedir-pathname)))) (when (probe-file init-file) (load init-file)))) (list \".clinit.cl\" \"clinit.cl\"))"
+            (when with-rc "-e")
+            (when with-rc "(mapcar #'(lambda (filename) (let ((init-file (merge-pathnames filename (user-homedir-pathname)))) (when (probe-file init-file) (load init-file)))) (list \".clinit.cl\" \"clinit.cl\"))")
             "-e" (eval-wrapper lisp file)))
 
 (defclass ccl (implementation)

--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -252,7 +252,7 @@
   (run-lisp lisp
             (unless with-rc "--qq")
             (when with-rc "-e")
-            (when with-rc "(mapcar #'(lambda (filename) (let ((init-file (merge-pathnames filename (user-homedir-pathname)))) (when (probe-file init-file) (load init-file)))) (list \".clinit.cl\" \"clinit.cl\"))")
+            (when with-rc "(mapcar #'(lambda (init-file) (when (probe-file init-file) (load init-file))) (remove-duplicates (list (translate-logical-pathname \"sys:siteinit.cl\") (merge-pathnames \".clinit.cl\" (user-homedir-pathname)) (merge-pathnames \"clinit.cl\" (user-homedir-pathname)) (merge-pathnames \".clinit.cl\" *default-pathname-defaults*) (merge-pathnames \"clinit.cl\" *default-pathname-defaults*)) :test #'equal))")
             "-e" (eval-wrapper lisp file)))
 
 (defclass ccl (implementation)

--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -249,9 +249,9 @@
   (format NIL "(excl:exit ~d :quiet T)" code))
 
 (defmethod eval-in-lisp ((lisp allegro) (file pathname) with-rc)
-  ;; FIXME: Allegro seems to run -e /before/ rc files are loaded.
   (run-lisp lisp
             (unless with-rc "--qq")
+            "-e" "(mapcar #'(lambda (filename) (let ((init-file (merge-pathnames filename (user-homedir-pathname)))) (when (probe-file init-file) (load init-file)))) (list \".clinit.cl\" \"clinit.cl\"))"
             "-e" (eval-wrapper lisp file)))
 
 (defclass ccl (implementation)

--- a/cl-all.lisp
+++ b/cl-all.lisp
@@ -308,7 +308,7 @@
             (unless with-rc "--norc")
             "--eval" (eval-wrapper lisp file)))
 
-(defclass jscl (implementation) ()
+(defclass jscl (implementation)
   ((executable :initform '("jscl" "jscl-repl"))))
 
 (defmethod quit-form ((lisp jscl) code)


### PR DESCRIPTION
- fix JSCL executable
- fix Allegro: load rc files before run -e, see [13.0 Initialization and the sys:siteinit.cl and [.]clinit.cl files - Allegro CL Startup](https://franz.com/support/documentation/current/doc/startup.htm#init-files-1)